### PR TITLE
Modify nvm use the alias 'default'

### DIFF
--- a/nvm.fish
+++ b/nvm.fish
@@ -637,4 +637,4 @@ function nvm
     end
 end
 
-nvm ls default >/dev/null; and nvm use default >/dev/null; or true
+test (nvm ls default) != ""; and nvm use default >/dev/null; or true


### PR DESCRIPTION
`nvm ls default >/dev/null` does not become TRUE forever in fish shell.
